### PR TITLE
WL-1445 Make sure MessageBundleService doesn't stop shutdown.

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/messagebundle/impl/MessageBundleServiceImpl.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/messagebundle/impl/MessageBundleServiceImpl.java
@@ -52,7 +52,8 @@ public class MessageBundleServiceImpl extends HibernateDaoSupport implements Mes
      */
     private Set<String> indexedList = new HashSet<String>();
     private long scheduleDelay = 1000;
-    Timer timer = new Timer();
+    // We make sure it's a daemon so it doesn't hold up shutting down the JVM.
+    private Timer timer = new Timer(true);
 
     public void init() {
     }


### PR DESCRIPTION
When you use auto wiring this bean ends up getting started up, but because of it's non-daemon time wouldn't shutdown. It's been re-written in never versions of Sakai but this is a simple fix for us.
