### PR TITLE
WL-1704 Get the timezone correct.

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/site/impl/SiteRemovalLogger.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/site/impl/SiteRemovalLogger.java
@@ -10,6 +10,8 @@ import org.sakaiproject.user.api.UserDirectoryService;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * This class just logs out when a site is removed and who by. At the moment this is useful as you can restore
@@ -23,7 +25,15 @@ public class SiteRemovalLogger implements SiteRemovalAdvisor {
 
 	private UserDirectoryService userDirectoryService;
 	private SiteService siteService;
-	private DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+	private DateFormat format;
+
+	public SiteRemovalLogger() {
+		format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+		// Dateformatter tries to use the current machine's timezone to format the date and this doesn't work
+		// historically (eg GMT/BST).
+		// This way we get back to UTC.
+		format.setTimeZone(TimeZone.getTimeZone("UTC"));
+	}
 
 	public void setUserDirectoryService(UserDirectoryService userDirectoryService) {
 		this.userDirectoryService = userDirectoryService;
@@ -54,7 +64,7 @@ public class SiteRemovalLogger implements SiteRemovalAdvisor {
 		if (site.isSoftlyDeleted()) {
 			message.append(" marked for deletion by: ").append(displayUser(site.getModifiedBy()));
 			if (site.getModifiedDate()!= null) {
-				message.append(" at: ").append(format.format(site.getModifiedDate()));
+				message.append(" at: ").append(displayDate(site.getModifiedDate()));
 			}
 		}
 		message.append(" removed by: ").append(displayUser(userDirectoryService.getCurrentUser()));
@@ -70,4 +80,14 @@ public class SiteRemovalLogger implements SiteRemovalAdvisor {
 		return (user == null)?"unknown":user.getDisplayName()+ "("+ user.getDisplayId()+ ")";
 
 	}
+
+	/**
+	 * Formats a date.
+	 * @param date The date to format.
+	 * @return A date in UTC.
+	 */
+	String displayDate(Date date) {
+		return format.format(date);
+	}
+
 }

--- a/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteRemovalLoggerTest.java
+++ b/kernel-impl/src/test/java/org/sakaiproject/site/impl/SiteRemovalLoggerTest.java
@@ -46,7 +46,7 @@ public class SiteRemovalLoggerTest {
 		when(userDirectoryService.getCurrentUser()).thenReturn(user);
 
 		assertEquals("Removing Site ID: siteId title: Site Title type: type marked for deletion by: Display " +
-				"Name(display-id) at: 1970-01-01T01:00Z removed by: Display Name(display-id)", logger.buildMessage(site));
+				"Name(display-id) at: 1970-01-01T00:00Z removed by: Display Name(display-id)", logger.buildMessage(site));
 	}
 
 	@Test
@@ -56,6 +56,12 @@ public class SiteRemovalLoggerTest {
 		when(site.isSoftlyDeleted()).thenReturn(true);
 		assertEquals("Removing Site ID: null title: null type: null marked for deletion by: unknown removed by: unknown",
 				logger.buildMessage(site));
+	}
+
+	@Test
+	public void testDateFormatting() {
+		Date date = new Date(0);
+		assertEquals("1970-01-01T00:00Z", logger.displayDate(date));
 	}
 
 


### PR DESCRIPTION
We force the formatter to be UTC as we don't know if the date was in GMT/BST so just print it out in UTC to be safe.
