### PR TITLE
WL-3215 Make sure load order is consistent.

### DIFF
--- a/component-manager/src/main/java/org/sakaiproject/util/ComponentsLoader.java
+++ b/component-manager/src/main/java/org/sakaiproject/util/ComponentsLoader.java
@@ -80,24 +80,17 @@ public class ComponentsLoader
 				M_log.warn("load: empty directory: " + componentsRoot);
 				return;
 			}
-			
-			List<File> packages = new ArrayList<File>(Arrays.asList(packageArray));
 
-			// for testing, we might reverse load order
-			final int reverse = System.getProperty("sakai.components.reverse.load") != null ? -1 : 1;
+			List<File> packages = Arrays.asList(packageArray);
 
 			// assure a consistent order - sort these files
-			Collections.sort(packages, new Comparator()
-			{
-				public int compare(Object o1, Object o2)
-				{
-					File f1 = (File) o1;
-					File f2 = (File) o2;
-					int sort = f1.compareTo(f2);
-					return sort * reverse;
-				}
-			});
-			
+			Collections.sort(packages);
+
+			// for testing, we might reverse load order
+			if (System.getProperty("sakai.components.reverse.load") != null) {
+				Collections.reverse(packages);
+			}
+
 			M_log.info("load: loading components from: " + componentsRoot);
 
 			// process the packages
@@ -257,6 +250,10 @@ public class ComponentsLoader
 
 			if (jars != null)
 			{
+				// We sort them so that we get predictable results when loading classes.
+				// Otherwise sometimes you can end up with one class and other times you can end up with another
+				// depending on the order the listing is stored on the filesystem.
+				Arrays.sort(jars);
 				for (int j = 0; j < jars.length; j++)
 				{
 					try

--- a/component-manager/src/test/java/org/sakaiproject/util/Component.java
+++ b/component-manager/src/test/java/org/sakaiproject/util/Component.java
@@ -9,12 +9,19 @@ import java.io.StringWriter;
 import java.io.Writer;
 
 /**
+ * <p>
  * Represents a single Sakai component directory. Given an ID, a base dir,
  * and a {@link Compiler}, can generate its own directory layout and can
  * generate a near-guaranteed unique Java class and associated bean definition.
+ * </p>
+ * <p>
+ * It can also generate additional JARs in the component if supplied.
+ * </p>
+ * <p>
  * Cannot be instantiated if a component of the same ID has already been
  * created below the specified root directory. Cannot invoke {@link #generate()}
  * multiple times unless the underlying file system has been edited out-of-band.
+ * </p>
  *  
  * @author dmccallum@unicon.net
  *
@@ -24,27 +31,86 @@ public class Component {
 	private static final String CLASS_SRC_TEMPLATE = 
 		"package %1$s;\n" + 
 		"public class %2$s { }";
-	private static final String BEAN_DEF_TEMPLATE = 
+	private static final String BEAN_DEF_TEMPLATE_HEADER =
 		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 		"<!DOCTYPE beans PUBLIC \"-//SPRING//DTD BEAN//EN\" \"http://www.springframework.org/dtd/spring-beans.dtd\">\n" +
-		"<beans>\n" +
-			"\t<bean id=\"%1$s\" class=\"%1$s\" />\n" +
-		"</beans>";
+		"<beans>\n";
+	private static final String BEAN_DEF_TEMPLATE_BEAN =
+			"\t<bean id=\"%1$s\" class=\"%1$s\" />\n";
+	private static final String BEAN_DEF_TEMPLATE_FOOTER =
+			"</beans>";
 	private String id;
+	private Jar[] jars;
 	private File componentsRootDir;
 	private File componentDir;
 	private File webInfDir;
 	private File classesDir;
 	private File libDir;
 	private File srcDir;
+	private File dstDir;
 	private String pkgName;
 	private String className;
 	private File srcPkgDir;
 	private File classSrcFile;
 	private File beanDefsFile;
 	private Compiler compiler;
+
+	public class Jar {
+
+		private String name;
+		private String className;
+		private String classSrc;
+		private File srcPkgDir;
+		private File classSrcFile;
+
+		public Jar(String name) {
+			this.name = name;
+		}
+
+		public String getBeanId() {
+			return getBeanClass();
+		}
+
+		protected String getBeanClass() {
+			if ( pkgName == null || className == null ) {
+				return null;
+			}
+			return pkgName + "." + className;
+		}
+
+		protected void generateJavaSource() {
+			// Assume that folders are already created.
+			className = "ServiceImpl"+name + id;
+			String pkgAsPath = pkgName.replace(".", File.separator);
+			srcPkgDir = mkdir(srcDir, pkgAsPath);
+
+			classSrc = String.format(CLASS_SRC_TEMPLATE, pkgName, className);
+			classSrcFile = writeFile(srcPkgDir, className + ".java", classSrc);
+		}
+
+		protected String generateBeanDefs() {
+			return String.format(BEAN_DEF_TEMPLATE_BEAN, getBeanClass());
+		}
+
+		protected void compile() {
+			(Component.this).compile(classSrcFile.getAbsolutePath());
+		}
+
+		protected void move() {
+			try {
+				JarBuilder builder = new JarBuilder(new File(libDir, name +".jar").getAbsolutePath());
+				builder.start();
+				String pkgAsPath = pkgName.replace(".", File.separator);
+				builder.add(dstDir.getAbsolutePath(), pkgAsPath+ File.separator+ className+ ".class", true);
+				builder.stop();
+			} catch (IOException ioe) {
+				throw new IllegalStateException("Failed to create JAR", ioe);
+			}
+
+		}
+	}
 	
-	public Component(String id, String componentsRootDir, Compiler compiler) {
+	public Component(String id, String componentsRootDir, Compiler compiler, String... jars) {
 		if ( id == null ) {
 			throw new IllegalArgumentException("Must specify an ID");
 		}
@@ -64,10 +130,18 @@ public class Component {
 			throw new IllegalArgumentException("Must specify a Compiler");
 		}
 		this.compiler = compiler;
+		this.jars = new Jar[jars.length];
+		for (int i = 0; i < jars.length; i++) {
+			this.jars[i] =  new Jar(jars[i]);
+		}
 	}
 
 	public String getBeanId() {
 		return getBeanClass();
+	}
+
+	public Jar[] getJars() {
+		return jars;
 	}
 	
 	public String getDir() {
@@ -86,9 +160,14 @@ public class Component {
 			throw new IllegalStateException("Component already exists at " + componentDir);
 		}
 		layout();
-		compile();
+		compile(classSrcFile.getAbsolutePath());
+		move(dstDir, classesDir);
+		for (Jar jar : jars) {
+			jar.compile();
+			jar.move();
+		}
 	}
-	
+
 	protected void layout() {
 		makeComponentDir();
 		layoutWebapp();
@@ -113,7 +192,7 @@ public class Component {
 	
 	protected File mkdir(File parent, String name) {
 		File dir = new File(parent, name);
-		if (!(dir.mkdirs())) {
+		if ( !(dir.isDirectory() || dir.mkdirs()) ) {
 			throw new IllegalStateException("Unable to create dir at " + dir.getPath());
 		}
 		return dir;
@@ -121,6 +200,7 @@ public class Component {
 	
 	protected void generateJavaSource() {
 		srcDir = mkdir(componentDir, "src");
+		dstDir = mkdir(componentDir, "dst");
 		pkgName = getClass().getPackage().getName();
 		String pkgAsPath = 
 			pkgName.replace(".", File.separator);
@@ -128,10 +208,18 @@ public class Component {
 		className = "ServiceImpl" + id;
 		String classSrc = String.format(CLASS_SRC_TEMPLATE, pkgName, className);
 		classSrcFile = writeFile(srcPkgDir, className + ".java", classSrc);
+		for(Jar jar : jars) {
+			jar.generateJavaSource();
+		}
 	}
 	
 	protected void generateBeanDefs() {
-		String beanDefs = String.format(BEAN_DEF_TEMPLATE, getBeanClass());
+		String beanDefs = BEAN_DEF_TEMPLATE_HEADER;
+		beanDefs += String.format(BEAN_DEF_TEMPLATE_BEAN, getBeanClass());
+		for(Jar jar : jars) {
+			beanDefs += jar.generateBeanDefs();
+		}
+		beanDefs += BEAN_DEF_TEMPLATE_FOOTER;
 		beanDefsFile = writeFile(webInfDir, "components.xml", beanDefs);
 	}
 	
@@ -162,21 +250,39 @@ public class Component {
 		return file;
 	}
 
-	protected void compile() {
+	protected void compile(String sourceFile) {
 		String[] options = { "-g", 
 				"-source", 
 				"1.5", 
 				"-target", 
 				"1.5",
 				"-d",
-				classesDir.getAbsolutePath(),
+				dstDir.getAbsolutePath(),
 				"-sourcepath", 
 				srcDir.getAbsolutePath(),
-				classSrcFile.getAbsolutePath()};
+				sourceFile};
 		StringWriter sw = new StringWriter();
 		PrintWriter out = new PrintWriter(sw);
 		compiler.compile(options,out);
 		out.close();
 	}
+
+
+	private void move(File source, File destination) {
+		if (!(source.exists())) {
+			throw new IllegalArgumentException("File doesn't exist: "+ source);
+		}
+		if (!(destination.isDirectory())) {
+			throw new IllegalArgumentException("Destination is not a directory: "+ destination);
+		}
+		for (File file : source.listFiles()) {
+			File dest = new File(destination, file.getName());
+			if (!(file.renameTo(dest))) {
+				throw new IllegalStateException("Failed to move: "+ file+ " to: "+ dest);
+			}
+		}
+	}
+
+
 
 }

--- a/component-manager/src/test/java/org/sakaiproject/util/ComponentBuilder.java
+++ b/component-manager/src/test/java/org/sakaiproject/util/ComponentBuilder.java
@@ -32,15 +32,20 @@ public class ComponentBuilder {
 	}
 
 	public Component buildComponent() {
+		return buildComponent(nextComponentId());
+	}
+
+	public Component buildComponent(String id, String... jars) {
 		if ( !(isUseable()) ) {
 			throw new IllegalStateException("ComponentBuilder not currently useable, probably because the JDK compiler is unavailable.");
 		}
 		initComponentsRootDir();
-		Component component = new Component(nextComponentId(), 
-				componentsRootDir.getAbsolutePath(), compiler);
+		Component component = new Component(id,
+				componentsRootDir.getAbsolutePath(), compiler, jars);
 		component.generate();
 		return component;
 	}
+
 
 	protected String nextComponentId() {
 		return Long.toString((long)(Math.random() * 2821109907456L), 36);

--- a/component-manager/src/test/java/org/sakaiproject/util/ComponentsLoaderTest.java
+++ b/component-manager/src/test/java/org/sakaiproject/util/ComponentsLoaderTest.java
@@ -1,9 +1,11 @@
 package org.sakaiproject.util;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.*;
 
+import com.sun.jmx.remote.internal.ArrayQueue;
 import junit.framework.TestCase;
 
 import org.sakaiproject.component.impl.SpringCompMgr;
@@ -86,7 +88,23 @@ public class ComponentsLoaderTest extends TestCase {
 		// (also for reasons outlined in the javadoc)
 		assertNotNull(componentMgr.getApplicationContext().getBean(component.getBeanId()));
 	}
-	
+
+	/**
+	 * This us very similar to the previous test except that now we check that we can also load components
+	 * from JAR files within the lib folder.
+	 */
+	public void testLoadRegisterJarComponentWithManager() {
+		if ( !(builder.isUseable()) ) {
+			sayUnusableBuilder("testLoadRegistersComponentWithComponentManager()");
+			return;
+		}
+		Component component = builder.buildComponent("test", "Jar1");
+		loader.load(componentMgr.getApplicationContext(), builder.getComponentsRootDir().getAbsolutePath());
+		for (Component.Jar jar : component.getJars()) {
+			assertNotNull(componentMgr.getApplicationContext().getBean(jar.getBeanId()));
+		}
+	}
+
 	/**
 	 * Same as {@link #testLoadRegistersComponentWithComponentManager()} but for
 	 * several components. The intent here is to (hopefully) distinguish clearly
@@ -138,7 +156,7 @@ public class ComponentsLoaderTest extends TestCase {
 	}
 	
 	/**
-	 * Verifies that {@link ComponentsLoader#load(ComponentManager, String)}
+	 * Verifies that {@link ComponentsLoader#load(org.springframework.context.ConfigurableApplicationContext, String)}
 	 * dispatches internally in the expected fashion. This enables more
 	 * direct testing of special implementations of those delegated-to
 	 * methods because it guarantees that the internal "protected" 
@@ -218,7 +236,78 @@ public class ComponentsLoaderTest extends TestCase {
 		assertEquals("Did not invoke newPackageClassLoader()", 
 				expectedJournal, journal);
 	}
-	
+
+	/**
+	 * This test verifies that when the components folder is loaded the components are processed
+	 * in an alphabetical order rather than the order in which they are returned from the filesystem.
+	 * We want this so that we get repeatable loads of the component manager.
+	 * This test depends on the filesystem order. If the filesystem always returns the files
+	 * alphabetically it won't fail.
+	 */
+	public void testComponentLoadOrder() {
+		if ( !(builder.isUseable()) ) {
+			sayUnusableBuilder("testLoadComponentPackageDispatch()");
+			return;
+		}
+		// Reverse alphabetical
+		List<String> expectedJournal = new ArrayList<String>() {{
+			add("sakai-z-pack"); add("sakai-b-pack"); add("sakai-a-pack");
+		}};
+		final Component componentA = builder.buildComponent("a");
+		final Component componentZ = builder.buildComponent("z");
+		final Component componentB = builder.buildComponent("b");
+		final List<String> journal = new ArrayList<String>();
+		loader = new ComponentsLoader() {
+			protected ClassLoader newPackageClassLoader(File dir) {
+				journal.add(dir.getName());
+				return super.newPackageClassLoader(dir);
+			}
+		};
+		try {
+			// We reverse it so that we are more sure the correct code is getting run.
+			System.setProperty("sakai.components.reverse.load", "true");
+			loader.load(componentMgr.getApplicationContext(),
+					builder.getComponentsRootDir().getAbsolutePath());
+		} finally {
+			System.clearProperty("sakai.components.reverse.load");
+		}
+		assertEquals("The components didn't get sorted.", expectedJournal, journal);
+	}
+
+	/**
+	 * This test verifies that when there are multiple JARs within a components folder the JARs are
+	 * processed in a alphabetical order. This test may not break as we might get the correct order back
+	 * from the filesystem.
+	 */
+	public void testJarLoadOrder() {
+		if ( !(builder.isUseable()) ) {
+			sayUnusableBuilder("testLoadComponentPackageDispatch()");
+			return;
+		}
+		Component component = builder.buildComponent("jarloadorder", "Jar1", "Jar2", "Jar3");
+		final List<String> expectedJournal = new ArrayList<String>() {{
+			add("Jar1.jar"); add("Jar2.jar"); add("Jar3.jar");
+		}};
+		final Queue<String> journal = new LinkedList<String>();
+		loader = new ComponentsLoader() {
+			@Override
+			protected ClassLoader newPackageClassLoader(File dir) {
+				URLClassLoader classLoader = (URLClassLoader)super.newPackageClassLoader(dir);
+				for (URL url : classLoader.getURLs()) {
+					// When we have test components without classes folder this test can be simpler.
+					if (url.getFile().endsWith(".jar")) {
+						journal.add(url.getFile());
+					}
+				}
+				return classLoader;
+			}
+		};
+		loader.load(componentMgr.getApplicationContext(), builder.getComponentsRootDir().getAbsolutePath());
+		for(String jar : expectedJournal) {
+			assertTrue("Didn't find the expected jar at the correct position.", journal.poll().endsWith(jar));
+		}
+	}
+
 	
 	private void sayUnusableBuilder(String invokingMethod) {
 		System.out.println("Unable to execute " + invokingMethod +", probably b/c necessary code generation tools are not available. Please see http://maven.apache.org/general.html#tools-jar-dependency for information on making tools.jar visible in the Maven classpaths.");

--- a/component-manager/src/test/java/org/sakaiproject/util/JarBuilder.java
+++ b/component-manager/src/test/java/org/sakaiproject/util/JarBuilder.java
@@ -1,0 +1,82 @@
+package org.sakaiproject.util;
+
+import java.io.*;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+/**
+ * Just allows simple building of a JAR file.
+ *
+ * @link http://stackoverflow.com/questions/1281229/how-to-use-jaroutputstream-to-create-a-jar-file
+ */
+public class JarBuilder {
+
+	private final File file;
+	private JarOutputStream target;
+
+	public JarBuilder(String file) {
+		this.file = new File(file);
+	}
+
+	public void start() throws IOException {
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+		target = new JarOutputStream(new FileOutputStream(file), manifest);
+	}
+
+	public void stop() throws IOException {
+		target.close();
+	}
+
+	/**
+	 * Recursively add files to a JAR archive.
+	 *
+	 * @param directory The file/directory to add.
+	 * @param file      File contained in the directory to add.
+	 * @param remove    If true remove files we process.
+	 * @throws IOException If something went wrong.
+	 */
+	public void add(String directory, String file, boolean remove) throws IOException {
+		BufferedInputStream in = null;
+		try {
+			File source = new File(directory, file);
+			if (source.isDirectory()) {
+				String name = file.replace("\\", "/");
+				if (!name.isEmpty()) {
+					if (!name.endsWith("/"))
+						name += "/";
+					JarEntry entry = new JarEntry(name);
+					entry.setTime(source.lastModified());
+					target.putNextEntry(entry);
+					target.closeEntry();
+				}
+				for (String nestedFile : source.list()) {
+					add(directory, file + File.separator + nestedFile, remove);
+				}
+			} else {
+
+				JarEntry entry = new JarEntry(file.replace("\\", "/"));
+				entry.setTime(source.lastModified());
+				target.putNextEntry(entry);
+				in = new BufferedInputStream(new FileInputStream(source));
+
+				byte[] buffer = new byte[1024];
+				while (true) {
+					int count = in.read(buffer);
+					if (count == -1)
+						break;
+					target.write(buffer, 0, count);
+				}
+				target.closeEntry();
+			}
+			if (remove) {
+				source.delete();
+			}
+		} finally {
+			if (in != null)
+				in.close();
+		}
+	}
+}


### PR DESCRIPTION
Recently we had an issue where the JARs in a component were getting loaded in a different order based on the order of files in the filesystem. This caused a tool to break.

We now sort the list of files returned from the filesystem to be alphabetical and then load them in that order. This should result in predictable deployments.

I've also updated the loading of components to simplify the code and added a test to check that components are loaded in alphabetical order. These tests are hard to make fail as there isn't an easy way to force the list of files be in a non alphabetic order.

The Component/Jar test classes could do with a little refactor so that you can create a component without anything in the classes folder, but I've spent enough time on this for now.
