### PR TITLE
WL-3337 KNL-1276 Don’t NPE on ResourceProperty lists.

### DIFF
--- a/kernel-storage-util/src/main/java/org/sakaiproject/util/BaseDbFlatStorage.java
+++ b/kernel-storage-util/src/main/java/org/sakaiproject/util/BaseDbFlatStorage.java
@@ -1363,8 +1363,10 @@ public class BaseDbFlatStorage
 				fields[3] = extraId;
 			}
 
+			// The value might be null if it's a list of values.
+			// TODO support persisting to the database lists of values.
 			// dont write it if there's only an empty string for value
-			if (value.length() > 0)
+			if (value != null && value.length() > 0)
 			{
 				m_sql.dbWrite(statement, fields);
 			}


### PR DESCRIPTION
Don’t blow up when attempting to save a ResourceProperty object with a list of values. Really we should support persisting them, but that’s lots of work.
