### PR TITLE
WL-3239 - Switch the default behaviour so that WebLearn page headers (in...

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
@@ -114,6 +114,9 @@ public class HtmlPageFilter implements ContentFilter {
 		String siteSkin = getSiteSkin(entity);
 		String forcePopups = getForcePopupsOnMixedContent();
 
+		// yes = quirks mode (no doctype)
+		// auto = standards mode
+		// standards = standards mode
 		final boolean detectHtml = addHtml == null || addHtml.equals("auto");
 		String title = getTitle(content);
 		StringBuilder header = new StringBuilder();

--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
@@ -117,7 +117,7 @@ public class HtmlPageFilter implements ContentFilter {
 		final boolean detectHtml = addHtml == null || addHtml.equals("auto");
 		String title = getTitle(content);
 		StringBuilder header = new StringBuilder();
-		if ("standards".equals(addHtml)) {
+		if ("standards".equals(addHtml) || addHtml.equals("auto")) {
 			header.append(doctype);
 		}
 		header.append(MessageFormat.format(headerTemplate, skinRepo, siteSkin, title, forcePopups));

--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
@@ -120,7 +120,7 @@ public class HtmlPageFilter implements ContentFilter {
 		final boolean detectHtml = addHtml == null || addHtml.equals("auto");
 		String title = getTitle(content);
 		StringBuilder header = new StringBuilder();
-		if ("standards".equals(addHtml) || addHtml.equals("auto")) {
+		if ("standards".equals(addHtml) || "auto".equals(addHtml)) {
 			header.append(doctype);
 		}
 		header.append(MessageFormat.format(headerTemplate, skinRepo, siteSkin, title, forcePopups));


### PR DESCRIPTION
Switch the default behaviour so that WebLearn page headers (in Resources) always use standards mode

Adding logic to say that if WebLeanr mode is 'Auto' then include DOCTYPE
