### PR TITLE
WL-1834 We didn’t lose our fix, but it got broken.

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -5554,7 +5554,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 				//				}
 				edit.setAvailability(resource.isHidden(), resource.getReleaseDate(), resource.getRetractDate());
 
-				commitResource(edit,NotificationService.NOTI_OPTIONAL);
+				commitResource(edit,NotificationService.NOTI_NONE);
 				// close the edit object
 				((BaseResourceEdit) edit).closeEdit();
 


### PR DESCRIPTION
SAK-24432 Meant that when any item in resources was copied notifications were sent (this was a dropbox related fix). The easiest solution without changing the API is to just revert the “fix”.

Revert "SAK-24432 - Use optional notifications for copied resources instead of none"

This reverts commit 7e79cf0f140ffda78c77484ac33cad17196e2d33.
