### PR TITLE
contact_us_email_from_address_bug : Change from-address to the actual sender

### DIFF
--- a/api/src/main/java/org/sakaiproject/email/api/EmailService.java
+++ b/api/src/main/java/org/sakaiproject/email/api/EmailService.java
@@ -164,4 +164,14 @@ public interface EmailService
 
 	List<EmailAddress> send(EmailMessage message, boolean messagingException) throws AddressValidationException,
 			NoRecipientsException, MessagingException;
+
+	/**
+	 * Configuration: smtp mail envelope return address.
+	 *
+	 * @param value
+	 *        The smtp mail from address string.
+	 */
+	public void setSmtpFrom(String value);
+
+    String getSmtpFrom();
 }

--- a/kernel-impl/src/main/java/org/sakaiproject/email/impl/BasicEmailService.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/email/impl/BasicEmailService.java
@@ -252,6 +252,15 @@ public class BasicEmailService implements EmailService
 	/** Configuration: optional smtp mail envelope return address. */
 	protected String m_smtpFrom = null;
 
+
+	/**
+	 * Return smtp mail envelope return address.
+	 */
+	public String getSmtpFrom()
+	{
+		return m_smtpFrom;
+	}
+
 	/**
 	 * Configuration: smtp mail envelope return address.
 	 * 


### PR DESCRIPTION
The bug is that emails from the Contact Us tool are being shown as
from "WebLearnweblearn-noreply@it.ox.ac.uk" whereas they should
show the sender's email address

Here I am adding the setter interface method for the smtpFrom variable
(so that it can be called from SakaiProxy)
and a getter method for it.

The idea is that we set the basicService's smptFrom then after the email is sent we reutnr it to
its original value.

Linked to https://github.com/ox-it/wl-feedback/pull/28
