### PR TITLE
WL-2956 Correctly replace parameter in HTML footer.

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/HtmlPageFilter.java
@@ -70,7 +70,7 @@ public class HtmlPageFilter implements ContentFilter {
   // and the user can view youtube videos without having to allow insecure content, but they still get the warning.
 	private String footerTemplate = "\n" +
 "  </body>\n" +
-"    <script type=\"text/javascript\" language=\"JavaScript\">{3}</script>\n" +
+"    <script type=\"text/javascript\" language=\"JavaScript\">{0}</script>\n" +
 "</html>\n";
 
 	public void setEntityManager(EntityManager entityManager) {


### PR DESCRIPTION
When I refactored this I had the positional parameter wrong, so it didn’t get replaced correctly.
