### PR TITLE
WL-3014 Prevent shutdown deadlock.

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/cluster/impl/SakaiClusterService.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/cluster/impl/SakaiClusterService.java
@@ -505,7 +505,7 @@ public class SakaiClusterService implements ClusterService
 									updateOurStatus(serverIdInstance);
 									m_updateStatus = false;
 								}
-								else
+								if(!m_updateStatus || m_maintenanceCheckerStop)
 								{
 									throw e;
 								}


### PR DESCRIPTION
When shutting down, we would change the status and interrupt the thread but before the other thread could process the interrupt we would also mark the maintenance thread to stop and interrupt it again. Then when the interrupt was processed we would jump out of sleep, see we were asked to change status, update the DB and then go back to sleep for the remainder of the sleep period.

The fix means we re-throw the error when we-re in shutdown which breaks us out of the fixed sleep loop.
