### PR TITLE
WL-3809 Change the order of the cache headers.

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -6833,7 +6833,8 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 
 				ArrayList<Range> ranges = parseRange(req, res, len);
 				res.addHeader("Accept-Ranges", "bytes");
-				res.addHeader("Cache-Control", "max-age=0, no-cache, no-store");
+				// To allow IE8 to download files the order matters
+				res.addHeader("Cache-Control", "max-age=0, no-store, no-cache");
 
 		        if (req.getHeader("Range") == null || (ranges == null) || (ranges.isEmpty())) {
 		        	


### PR DESCRIPTION
IE8 throws errors when attempting to download file if the Cache header values are ordered a different way.
