### PR TITLE
WL-3869: Revert policy file to removing all script tags / fixes tests  

### DIFF
--- a/kernel-impl/src/main/resources/antisamy/high-security-policy.xml
+++ b/kernel-impl/src/main/resources/antisamy/high-security-policy.xml
@@ -1434,19 +1434,7 @@
         <tag name="title" action="truncate"/>
 
         <!-- Tags related to JavaScript -->
-        <tag name="script" action="validate">
-            <attribute name="src">
-                <regexp-list>
-                    <regexp value="http[\s\S]*(/library/js/jquery/jquery-1.9.1.min.js)"/>
-                    <regexp value="http[\s\S]*(/library/editor/ckextraplugins/common/js/preload-ckeditor-assets.js)"/>
-                </regexp-list>
-            </attribute>
-            <attribute name="type">
-                <literal-list>
-                    <literal value="text/javascript"/>
-                </literal-list>
-            </attribute>
-        </tag>
+        <tag name="script" action="remove"/>
         <tag name="noscript" action="validate"/> <!-- although no javascript can fire inside a noscript tag, css is still a viable attack vector -->
 
         <!-- Frame & related tags -->


### PR DESCRIPTION
By only showing the first 4 widgets in non-Resources tools, we are able to put back this Antisamy change of loosening the security on script tags because these widgets do not use script tags. 
