### PR TITLE
WL-3836: data-max can sometimes be an empty string as well as a number

### DIFF
--- a/kernel-impl/src/main/resources/antisamy/high-security-policy.xml
+++ b/kernel-impl/src/main/resources/antisamy/high-security-policy.xml
@@ -220,7 +220,7 @@
 
         <attribute name="data-max" description="One of the set of data-* attributes used to store custom data private to the page or application">
             <regexp-list>
-                <regexp name="number"/>
+                <regexp name="anything"/>
             </regexp-list>
         </attribute>
 


### PR DESCRIPTION
When it's an empty string, this antisamy rule incorrectly strips it.
