### PR TITLE
Wl 3776

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/CollectionAccessFormatter.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/CollectionAccessFormatter.java
@@ -176,7 +176,7 @@ public class CollectionAccessFormatter
 			// Iterate through content items
 
 			URI baseUri = new URI(x.getUrl());
-			String hiddenClass = x.isHidden()? "inactive" : "" ;
+			String hiddenClass = x.isAvailable() ? "" : " inactive";
 			for (ContentEntity content : members) {
 
 				ResourceProperties properties = content.getProperties();
@@ -214,10 +214,10 @@ public class CollectionAccessFormatter
 					URI contentUri = new URI(contentUrl);
 					URI relativeUri = baseUri.relativize(contentUri);
 					contentUrl = relativeUri.toString();
-
 					if(content.isHidden()) {
-						hiddenClass="inactive";
+						hiddenClass = " inactive";
 					}
+
 
 					if (isCollection)
 					{

--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/CollectionAccessFormatter.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/CollectionAccessFormatter.java
@@ -176,9 +176,9 @@ public class CollectionAccessFormatter
 			// Iterate through content items
 
 			URI baseUri = new URI(x.getUrl());
-			String hiddenClass = x.isAvailable() ? "" : " inactive";
+			String hiddenClass;
 			for (ContentEntity content : members) {
-
+				hiddenClass = x.isAvailable() ? "" : " inactive";
 				ResourceProperties properties = content.getProperties();
 				boolean isCollection = content.isCollection();
 				String xs = content.getId();
@@ -214,7 +214,7 @@ public class CollectionAccessFormatter
 					URI contentUri = new URI(contentUrl);
 					URI relativeUri = baseUri.relativize(contentUri);
 					contentUrl = relativeUri.toString();
-					if(content.isHidden()) {
+					if(!content.isAvailable()) {
 						hiddenClass = " inactive";
 					}
 

--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/CollectionAccessFormatter.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/CollectionAccessFormatter.java
@@ -176,7 +176,7 @@ public class CollectionAccessFormatter
 			// Iterate through content items
 
 			URI baseUri = new URI(x.getUrl());
-						
+			String hiddenClass = x.isHidden()? "inactive" : "" ;
 			for (ContentEntity content : members) {
 
 				ResourceProperties properties = content.getProperties();
@@ -215,7 +215,9 @@ public class CollectionAccessFormatter
 					URI relativeUri = baseUri.relativize(contentUri);
 					contentUrl = relativeUri.toString();
 
-					final String hiddenClass = content.isHidden() ? " inactive" : "";
+					if(content.isHidden()) {
+						hiddenClass="inactive";
+					}
 
 					if (isCollection)
 					{

--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/CollectionAccessFormatter.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/CollectionAccessFormatter.java
@@ -176,9 +176,10 @@ public class CollectionAccessFormatter
 			// Iterate through content items
 
 			URI baseUri = new URI(x.getUrl());
+			String hiddenClassParent = x.isAvailable() ? "" : " inactive";
 			String hiddenClass;
 			for (ContentEntity content : members) {
-				hiddenClass = x.isAvailable() ? "" : " inactive";
+				hiddenClass = hiddenClassParent;
 				ResourceProperties properties = content.getProperties();
 				boolean isCollection = content.isCollection();
 				String xs = content.getId();


### PR DESCRIPTION
The logic in the resources view, greying out of resources is based on the selected parent's hidden attribute value.

In the collectionAccessFormatter , it was previously checking hidden attribute value for each of the child items. I've moved the line setting css, above the for loop iteration of the members.  So it now sets inactive based on root and not on each of its members.

For the scenario where there is a folder which is not hidden but which has one of its child item visible, I've again checked the visibility inside the for loop and set the visibility only if the child items visibility is explicitly set to hidden.

The alternative to the above solution would be to write a recursive method( in ResourceAction.java) that iterates through the tree structure of a particular selected source folder and set each of its child item's hidden attribute to true everytime something is hidden.
