### PR TITLE
WL-3899 Dropbox to have username when archived

### DIFF
--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -9588,7 +9588,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		}
 
 		// return the current user's sort name
-		return getDisplayName(null,true);
+		return getDisplayName(null);
 
 	}
 
@@ -9703,7 +9703,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					{
 						ContentCollectionEdit edit = addValidPermittedCollection(userFolder);
 						ResourcePropertiesEdit props = edit.getPropertiesEdit();
-						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME,getDisplayName(user,false));
+						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME,getDisplayName(user));
 						props.addProperty(ResourceProperties.PROP_DESCRIPTION, rb.getString("use1"));
 						commitCollection(edit);
 					}
@@ -9804,7 +9804,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					{
 						ContentCollectionEdit edit = addValidPermittedCollection(userFolder);
 						ResourcePropertiesEdit props = edit.getPropertiesEdit();
-						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, getDisplayName(user,false));
+						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, getDisplayName(user));
 						props.addProperty(ResourceProperties.PROP_DESCRIPTION, rb.getString("use1"));
 						// props.addProperty(ResourceProperties.PROP_DESCRIPTION, PROP_MEMBER_DROPBOX_DESCRIPTION);
 						commitCollection(edit);
@@ -13869,8 +13869,8 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		return macroName;
 	}
 
-	private String getDisplayName(User userIn,boolean isUserdir) {
-		User user = isUserdir?userDirectoryService.getCurrentUser():userIn ;
+	private String getDisplayName(User userIn) {
+		User user = (userIn!= null)?userDirectoryService.getCurrentUser():userIn ;
 		String displayId = user.getDisplayId();
 		if (displayId != null && displayId.length() > 0) {
 			return user.getSortName() + " (" + displayId + ")";

--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -9588,13 +9588,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		}
 
 		// return the current user's sort name
-		String displayId = userDirectoryService.getCurrentUser().getDisplayId();
-		if(displayId != null && displayId.length()>0) {
-			return userDirectoryService.getCurrentUser().getSortName()+" ("+ displayId+")";
-		}
-		else {
-			return userDirectoryService.getCurrentUser().getSortName();
-		}
+		return getDisplayName(null,true);
 
 	}
 
@@ -9709,13 +9703,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					{
 						ContentCollectionEdit edit = addValidPermittedCollection(userFolder);
 						ResourcePropertiesEdit props = edit.getPropertiesEdit();
-						String displayId = user.getDisplayId();
-						if(displayId != null && displayId.length()>0) {
-							props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName() + " (" + displayId + ")");
-						}
-						else {
-							props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName());
-						}
+						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME,getDisplayName(user,false));
 						props.addProperty(ResourceProperties.PROP_DESCRIPTION, rb.getString("use1"));
 						commitCollection(edit);
 					}
@@ -9816,13 +9804,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					{
 						ContentCollectionEdit edit = addValidPermittedCollection(userFolder);
 						ResourcePropertiesEdit props = edit.getPropertiesEdit();
-						String displayId = user.getDisplayId();
-						if(displayId != null && displayId.length()>0) {
-							props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName() + " (" + displayId + ")");
-						}
-						else {
-							props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName());
-						}
+						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, getDisplayName(user,false));
 						props.addProperty(ResourceProperties.PROP_DESCRIPTION, rb.getString("use1"));
 						// props.addProperty(ResourceProperties.PROP_DESCRIPTION, PROP_MEMBER_DROPBOX_DESCRIPTION);
 						commitCollection(edit);
@@ -13885,6 +13867,17 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		
 		//unsupported, use macro name as is.
 		return macroName;
+	}
+
+	private String getDisplayName(User userIn,boolean isUserdir) {
+		User user = isUserdir?userDirectoryService.getCurrentUser():userIn ;
+		String displayId = user.getDisplayId();
+		if (displayId != null && displayId.length() > 0) {
+			return user.getSortName() + " (" + displayId + ")";
+		}
+		else {
+			return user.getSortName();
+		}
 	}
 
 } // BaseContentService

--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -9588,7 +9588,14 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		}
 
 		// return the current user's sort name
-		return userDirectoryService.getCurrentUser().getSortName()+" ("+ userDirectoryService.getCurrentUser().getDisplayId()+")";
+		String displayId = userDirectoryService.getCurrentUser().getDisplayId();
+		if(displayId != null && displayId.length()>0) {
+			return userDirectoryService.getCurrentUser().getSortName()+" ("+ displayId+")";
+		}
+		else {
+			return userDirectoryService.getCurrentUser().getSortName();
+		}
+
 	}
 
 	/**
@@ -9702,7 +9709,13 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					{
 						ContentCollectionEdit edit = addValidPermittedCollection(userFolder);
 						ResourcePropertiesEdit props = edit.getPropertiesEdit();
-						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName()+" ("+ user.getDisplayId()+")");
+						String displayId = user.getDisplayId();
+						if(displayId != null && displayId.length()>0) {
+							props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName() + " (" + displayId + ")");
+						}
+						else {
+							props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName());
+						}
 						props.addProperty(ResourceProperties.PROP_DESCRIPTION, rb.getString("use1"));
 						commitCollection(edit);
 					}
@@ -9803,7 +9816,13 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					{
 						ContentCollectionEdit edit = addValidPermittedCollection(userFolder);
 						ResourcePropertiesEdit props = edit.getPropertiesEdit();
-						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName()+" ("+ user.getDisplayId()+")");
+						String displayId = user.getDisplayId();
+						if(displayId != null && displayId.length()>0) {
+							props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName() + " (" + displayId + ")");
+						}
+						else {
+							props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName());
+						}
 						props.addProperty(ResourceProperties.PROP_DESCRIPTION, rb.getString("use1"));
 						// props.addProperty(ResourceProperties.PROP_DESCRIPTION, PROP_MEMBER_DROPBOX_DESCRIPTION);
 						commitCollection(edit);

--- a/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
+++ b/kernel-impl/src/main/java/org/sakaiproject/content/impl/BaseContentService.java
@@ -9588,7 +9588,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 		}
 
 		// return the current user's sort name
-		return userDirectoryService.getCurrentUser().getSortName();
+		return userDirectoryService.getCurrentUser().getSortName()+" ("+ userDirectoryService.getCurrentUser().getDisplayId()+")";
 	}
 
 	/**
@@ -9702,7 +9702,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					{
 						ContentCollectionEdit edit = addValidPermittedCollection(userFolder);
 						ResourcePropertiesEdit props = edit.getPropertiesEdit();
-						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName());
+						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName()+" ("+ user.getDisplayId()+")");
 						props.addProperty(ResourceProperties.PROP_DESCRIPTION, rb.getString("use1"));
 						commitCollection(edit);
 					}
@@ -9803,7 +9803,7 @@ SiteContentAdvisorProvider, SiteContentAdvisorTypeRegistry, EntityTransferrerRef
 					{
 						ContentCollectionEdit edit = addValidPermittedCollection(userFolder);
 						ResourcePropertiesEdit props = edit.getPropertiesEdit();
-						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName());
+						props.addProperty(ResourceProperties.PROP_DISPLAY_NAME, user.getSortName()+" ("+ user.getDisplayId()+")");
 						props.addProperty(ResourceProperties.PROP_DESCRIPTION, rb.getString("use1"));
 						// props.addProperty(ResourceProperties.PROP_DESCRIPTION, PROP_MEMBER_DROPBOX_DESCRIPTION);
 						commitCollection(edit);

--- a/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
+++ b/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
@@ -102,7 +102,6 @@ public class ZipContentUtil {
 			// Store the compressed archive in the repository
 			String resourceId = reference.getId().substring(0,reference.getId().lastIndexOf(Entity.SEPARATOR));
 			String resourceName = extractName(resourceId);
-			String originalResourceName = resourceName;
 			String homeCollectionId = (String) toolSession.getAttribute(STATE_HOME_COLLECTION_ID);
 			if(homeCollectionId != null && homeCollectionId.equals(reference.getId())){
 				//place the zip file into the home folder of the resource tool
@@ -113,7 +112,6 @@ public class ZipContentUtil {
 					resourceName = homeName;
 				}				
 			}
-
 			int count = 0;
 			ContentResourceEdit resourceEdit = null;
 			String displayName="";
@@ -419,29 +417,29 @@ public class ZipContentUtil {
 		String filename = resource.getId().substring(rootId.length(),resource.getId().length());
 
 		//Inorder to have username as the folder name rather than having eids
-		if(rootId.indexOf("group-user")!=-1) {
+		if(rootId.indexOf("group-user")!=-1 && ServerConfigurationService.getBoolean("dropbox.zip.haveDisplayname", true)) {
 			if (filename != null && filename.length() > 0) {
-				String filenameArr[] = filename.split(Entity.SEPARATOR);
-				if (filenameArr.length > 1) {
-					ContentCollectionEdit collectionEdit = (ContentCollectionEdit) ContentHostingService.getCollection(rootId + filenameArr[0] + Entity.SEPARATOR);
-					ResourcePropertiesEdit props = collectionEdit.getPropertiesEdit();
-					String displayName = props.getProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME);
-					try {
-						String uniqueId = UserDirectoryService.getUser(filenameArr[0]).getDisplayId();
+				try {
+					String filenameArr[] = filename.split(Entity.SEPARATOR);
+					ContentCollectionEdit collectionEdit;
+					ResourcePropertiesEdit props;
+					String displayName;
+					String uniqueId;
+					if (filenameArr.length > 1) {
+						collectionEdit = (ContentCollectionEdit) ContentHostingService.getCollection(rootId + filenameArr[0] + Entity.SEPARATOR);
+						props = collectionEdit.getPropertiesEdit();
+						displayName = props.getProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME);
+						uniqueId = UserDirectoryService.getUser(filenameArr[0]).getDisplayId();
 						filename = displayName + "(" + uniqueId + ")" + Entity.SEPARATOR + filenameArr[1];
-					} catch (UserNotDefinedException e) {
-						LOG.warn("Not able to find user for id:" + filenameArr[0]);
-					}
-				} else {
-					ContentCollectionEdit collectionEdit = (ContentCollectionEdit) ContentHostingService.getCollection(rootId);
-					ResourcePropertiesEdit props = collectionEdit.getPropertiesEdit();
-					String displayName = props.getProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME);
-					try {
-						String uniqueId = UserDirectoryService.getUser(extractName(rootId)).getDisplayId();
+					} else {
+						collectionEdit = (ContentCollectionEdit) ContentHostingService.getCollection(rootId);
+						props = collectionEdit.getPropertiesEdit();
+						displayName = props.getProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME);
+						uniqueId = UserDirectoryService.getUser(extractName(rootId)).getDisplayId();
 						filename = displayName + "(" + uniqueId + ")" + Entity.SEPARATOR + filenameArr[0];
-					} catch (UserNotDefinedException e) {
-						LOG.warn("Not able to find user for id:" + extractName(rootId));
 					}
+				} catch (UserNotDefinedException e) {
+					LOG.warn("Not able to find user for id:" + extractName(rootId));
 				}
 			}
 		}

--- a/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
+++ b/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
@@ -415,16 +415,16 @@ public class ZipContentUtil {
 				try {
 					filename = getContainingFolderDisplayName(rootId, filename);
 				} catch(TypeException e){
-					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId)+e.getStackTrace());
+					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
 					return;
 				} catch(IdUnusedException e ){
-					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId)+e.getStackTrace());
+					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
 					return;
 				} catch(PermissionException e){
-					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId)+e.getStackTrace());
+					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
 					return;
 				} catch (Exception e) {
-					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId)+e.getStackTrace());
+					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
 					return;
 				}
 		}

--- a/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
+++ b/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
@@ -125,7 +125,7 @@ public class ZipContentUtil {
 					newResourceName += ZIP_EXTENSION;
 
 					ContentCollectionEdit currentEdit;
-					if(reference.getId().split(Entity.SEPARATOR).length>3 && reference.getId().indexOf("group-user")!=-1) {
+					if(reference.getId().split(Entity.SEPARATOR).length>3 && ContentHostingService.isInDropbox(reference.getId())) {
 						currentEdit = (ContentCollectionEdit) ContentHostingService.getCollection(resourceId + Entity.SEPARATOR);
 						displayName = currentEdit.getProperties().getProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME);
 						if (displayName != null && displayName.length() > 0) {
@@ -411,22 +411,22 @@ public class ZipContentUtil {
 	private void storeContentResource(String rootId, ContentResource resource, ZipOutputStream out) throws Exception {
 		String filename = resource.getId().substring(rootId.length(),resource.getId().length());
 		//Inorder to have username as the folder name rather than having eids
-		if(rootId.indexOf("group-user")!=-1 && ServerConfigurationService.getBoolean("dropbox.zip.haveDisplayname", true)) {
-				try {
-					filename = getContainingFolderDisplayName(rootId, filename);
-				} catch(TypeException e){
-					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
-					return;
-				} catch(IdUnusedException e ){
-					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
-					return;
-				} catch(PermissionException e){
-					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
-					return;
-				} catch (Exception e) {
-					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
-					return;
-				}
+		if(ContentHostingService.isInDropbox(rootId) && ServerConfigurationService.getBoolean("dropbox.zip.haveDisplayname", true)) {
+			try {
+				filename = getContainingFolderDisplayName(rootId, filename);
+			} catch(TypeException e){
+				LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
+				return;
+			} catch(IdUnusedException e ){
+				LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
+				return;
+			} catch(PermissionException e){
+				LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
+				return;
+			} catch (Exception e) {
+				LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId), e.getCause());
+				return;
+			}
 		}
 		ZipEntry zipEntry = new ZipEntry(filename);
 		zipEntry.setSize(resource.getContentLength());

--- a/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
+++ b/kernel-util/src/main/java/org/sakaiproject/content/util/ZipContentUtil.java
@@ -429,17 +429,15 @@ public class ZipContentUtil {
 						collectionEdit = (ContentCollectionEdit) ContentHostingService.getCollection(rootId + filenameArr[0] + Entity.SEPARATOR);
 						props = collectionEdit.getPropertiesEdit();
 						displayName = props.getProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME);
-						uniqueId = UserDirectoryService.getUser(filenameArr[0]).getDisplayId();
-						filename = displayName + "(" + uniqueId + ")" + Entity.SEPARATOR + filenameArr[1];
+						filename = displayName + Entity.SEPARATOR + filenameArr[1];
 					} else {
 						collectionEdit = (ContentCollectionEdit) ContentHostingService.getCollection(rootId);
 						props = collectionEdit.getPropertiesEdit();
 						displayName = props.getProperty(ResourcePropertiesEdit.PROP_DISPLAY_NAME);
-						uniqueId = UserDirectoryService.getUser(extractName(rootId)).getDisplayId();
-						filename = displayName + "(" + uniqueId + ")" + Entity.SEPARATOR + filenameArr[0];
+						filename = displayName + Entity.SEPARATOR + filenameArr[0];
 					}
-				} catch (UserNotDefinedException e) {
-					LOG.warn("Not able to find user for id:" + extractName(rootId));
+				} catch (Exception e) {
+					LOG.warn("Unexpected error occurred when trying to create Zip archive:" + extractName(rootId));
 				}
 			}
 		}


### PR DESCRIPTION
1. So far the resource was "eid/filename" which i've altered to be
   "(displayname of the folder+displayId of the user)/filename".
2.  I've concluded that the filename used so far was
      ->"filename" when archived at the student folder level
      ->"studentfolder eid/filename" when archived from root folder level
   Hence I've split file name rather than rootId or resourceId
3. If block handles the case when archived from root folder level and the else block handles the case of archiving from student folder level.
