### PR TITLE
WL-4285 Only send notifications to site members.

### DIFF
--- a/kernel-util/src/main/java/org/sakaiproject/util/SiteEmailNotification.java
+++ b/kernel-util/src/main/java/org/sakaiproject/util/SiteEmailNotification.java
@@ -122,11 +122,11 @@ public class SiteEmailNotification extends EmailNotification
 				users.retainAll(users2);
 			}
 
-			//only use direct site members for the base list of users
-			refineToSiteMembers(users, site);
-
 			// add any other users
 			addSpecialRecipients(users, ref);
+
+			//only use direct site members for the base list of users
+			refineToSiteMembers(users, site);
 
 			return users;
 		}


### PR DESCRIPTION
This means that special recipients can never be people who aren't members of the site.

The special users was adding people who weren't members of the site  but were in the !site.helper realm.
